### PR TITLE
rename module to name under namecoin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/btcsuite/btcd
+module github.com/namecoin/btcd
 
 require (
 	github.com/aead/siphash v1.0.1 // indirect


### PR DESCRIPTION
Since imports have been moved to Namecoin's repo in https://github.com/namecoin/btcd/pull/1, It is better to rename the module name too. Otherwise it is cumbersome for others to use namecoin/btcd as library  in other application like ncdns:

```
go: found github.com/namecoin/btcd/rpcclient in github.com/namecoin/btcd v0.20.0-beta
go: github.com/namecoin/ncdns imports
	github.com/namecoin/ncdns/server imports
	github.com/namecoin/btcd/rpcclient: github.com/namecoin/btcd@v0.20.0-beta: parsing go.mod:
	module declares its path as: github.com/btcsuite/btcd
	        but was required as: github.com/namecoin/btcd
```